### PR TITLE
Add API and statistics logic, db, data, attributes

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseStatisticAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackResponseStatisticAttributes.java
@@ -1,0 +1,92 @@
+package teammates.common.datatransfer.attributes;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
+import teammates.common.util.Assumption;
+import teammates.common.util.Const;
+import teammates.common.util.FieldValidator;
+import teammates.common.util.JsonUtils;
+import teammates.storage.entity.FeedbackResponse;
+import teammates.storage.entity.FeedbackResponseStatistic;
+
+public class FeedbackResponseStatisticAttributes extends EntityAttributes<FeedbackResponseStatistic> {
+
+    private Instant time;
+    private int count;
+
+    public FeedbackResponseStatisticAttributes(Instant time, int count) {
+        this.time = time.truncatedTo(ChronoUnit.MINUTES);
+        this.count = count;
+    }
+
+    public Instant getTime() {
+        return this.time;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public static FeedbackResponseStatisticAttributes valueOf(FeedbackResponseStatistic frs) {
+        FeedbackResponseStatisticAttributes frsa =
+                new FeedbackResponseStatisticAttributes(frs.getTime(), frs.getCount());
+        return frsa;
+    }
+
+    @Override
+    public List<String> getInvalidityInfo() {
+        List<String> errors = new ArrayList<>();
+        // TODO: how to implement this?
+        return errors;
+    }
+
+    @Override
+    public boolean isValid() {
+        return getInvalidityInfo().isEmpty();
+    }
+
+    @Override
+    public FeedbackResponseStatistic toEntity() {
+        return new FeedbackResponseStatistic(time, count);
+    }
+
+    @Override
+    public String toString() {
+        return "FeedbackResponseStatisticAttributes [time="
+                + time + ", count=" + count + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(this.time).append(this.count);
+        return stringBuilder.toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        } else if (this == other) {
+            return true;
+        } else if (this.getClass() == other.getClass()) {
+            FeedbackResponseStatisticAttributes otherFrsa = (FeedbackResponseStatisticAttributes) other;
+            return Objects.equals(this.time, otherFrsa.time)
+                    && Objects.equals(this.count, otherFrsa.count);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void sanitizeForSaving() {
+        // nothing to sanitize before saving
+    }
+}

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -19,6 +19,7 @@ import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseStatisticAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -35,6 +36,7 @@ import teammates.logic.core.DataBundleLogic;
 import teammates.logic.core.FeedbackQuestionsLogic;
 import teammates.logic.core.FeedbackResponseCommentsLogic;
 import teammates.logic.core.FeedbackResponsesLogic;
+import teammates.logic.core.FeedbackResponseStatisticsLogic;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.logic.core.InstructorsLogic;
 import teammates.logic.core.ProfilesLogic;
@@ -54,6 +56,8 @@ public class Logic {
     protected static final FeedbackSessionsLogic feedbackSessionsLogic = FeedbackSessionsLogic.inst();
     protected static final FeedbackQuestionsLogic feedbackQuestionsLogic = FeedbackQuestionsLogic.inst();
     protected static final FeedbackResponsesLogic feedbackResponsesLogic = FeedbackResponsesLogic.inst();
+    protected static final FeedbackResponseStatisticsLogic feedbackResponseStatisticsLogic =
+            FeedbackResponseStatisticsLogic.inst();
     protected static final FeedbackResponseCommentsLogic feedbackResponseCommentsLogic =
             FeedbackResponseCommentsLogic.inst();
     protected static final ProfilesLogic profilesLogic = ProfilesLogic.inst();
@@ -1346,6 +1350,16 @@ public class Logic {
 
     public List<FeedbackSessionAttributes> getFeedbackSessionsWhichNeedOpenEmailsToBeSent() {
         return feedbackSessionsLogic.getFeedbackSessionsWhichNeedOpenEmailsToBeSent();
+    }
+
+    public List<FeedbackResponseStatisticAttributes> getFeedbackResponseStatistics(Instant start, Instant end) {
+        return feedbackResponseStatisticsLogic.getFeedbackResponseStatistics(start, end);
+    }
+
+    public FeedbackResponseStatisticAttributes createFeedbackResponseStatistic(Instant time)
+            throws InvalidParametersException, EntityAlreadyExistsException {
+        Assumption.assertNotNull(time);
+        return feedbackResponseStatisticsLogic.createFeedbackResponseStatistic(time);
     }
 
     public String getSectionForTeam(String courseId, String teamName) {

--- a/src/main/java/teammates/logic/core/FeedbackResponseStatisticsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseStatisticsLogic.java
@@ -1,0 +1,71 @@
+package teammates.logic.core;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import teammates.common.datatransfer.AttributesDeletionQuery;
+import teammates.common.datatransfer.CourseRoster;
+import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.UserRole;
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseStatisticAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Assumption;
+import teammates.storage.api.FeedbackResponseStatisticsDb;
+
+/**
+ * Handles operations related to feedback response statistics.
+ *
+ * @see FeedbackResponseStatsticAttributes
+ * @see FeedbackResponseStatisticsDb
+ */
+public final class FeedbackResponseStatisticsLogic {
+
+    private static FeedbackResponseStatisticsLogic instance = new FeedbackResponseStatisticsLogic();
+    private static final FeedbackResponseStatisticsDb frsDb = new FeedbackResponseStatisticsDb();
+
+    private FeedbackResponseStatisticsLogic() {
+        // prevent initialization
+    }
+
+    /**
+     * Gets the list of feedback response statistics.
+     */
+    public List<FeedbackResponseStatisticAttributes> getFeedbackResponseStatistics(Instant start, Instant end) {
+        List<FeedbackResponseStatisticAttributes> frsa = frsDb.getFeedbackResponseStatistics(start, end);
+        return frsa;
+    }
+
+    /**
+     * Creates a feedback response statistic with count 1.
+     * If the feedback response statistic already exists, increment the count instead.
+     *
+     * @return created feedback response statistic
+     * @throws InvalidParametersException if the feedback response statistic is not valid
+     * @throws EntityAlreadyExistsException if the feedback response statistic already exists
+     */
+    public FeedbackResponseStatisticAttributes createFeedbackResponseStatistic(Instant time)
+            throws InvalidParametersException, EntityAlreadyExistsException {
+        if (frsDb.hasFeedbackResponseStatistic(time)) { // already exists, increment
+            return frsDb.incrementFeedbackResponseStatistic(time);
+        } else {                                        // does not exist, create
+            FeedbackResponseStatisticAttributes frsa = new FeedbackResponseStatisticAttributes(time, 1);
+            return frsDb.createEntity(frsa);
+        }
+    }
+
+    public static FeedbackResponseStatisticsLogic inst() {
+        return instance;
+    }
+}

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -938,4 +938,7 @@ public final class FeedbackSessionsLogic {
         return session.isVisible() && !questionsToAnswer.isEmpty();
     }
 
+    public int getFeedbackSessionStatistics(int startTime, int endTime) {
+        return 5;
+    }
 }

--- a/src/main/java/teammates/storage/api/FeedbackResponseStatisticsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseStatisticsDb.java
@@ -1,0 +1,81 @@
+package teammates.storage.api;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.VoidWork;
+import com.googlecode.objectify.cmd.LoadType;
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.common.datatransfer.AttributesDeletionQuery;
+import teammates.common.datatransfer.attributes.FeedbackResponseStatisticAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Assumption;
+import teammates.common.util.Const;
+import teammates.common.util.TimeHelper;
+import teammates.storage.entity.FeedbackResponseStatistic;
+
+/**
+ * Handles CRUD operations for feedback response statistics.
+ *
+ * @see FeedbackResponseStatistic
+ * @see FeedbackResponseStatisticAttributes
+ */
+public class FeedbackResponseStatisticsDb extends EntitiesDb<FeedbackResponseStatistic, FeedbackResponseStatisticAttributes> {
+
+    /**
+     * Gets all feedback response statistics between the start and end time.
+     */
+    public List<FeedbackResponseStatisticAttributes> getFeedbackResponseStatistics(Instant start, Instant end) {
+        List<FeedbackResponseStatistic> feedbackResponseStatisticList = load()
+                .filter("time >=", start)
+                .filter("time <", end)
+                .list();
+
+        return makeAttributes(feedbackResponseStatisticList).stream()
+                .sorted(Comparator.comparing(FeedbackResponseStatisticAttributes::getTime))
+                .collect(Collectors.toList());
+    }
+
+    public boolean hasFeedbackResponseStatistic(Instant time) {
+        return getFeedbackResponseStatistic(time) != null;
+    }
+
+    public FeedbackResponseStatisticAttributes incrementFeedbackResponseStatistic(Instant time) {
+        FeedbackResponseStatistic frs = getFeedbackResponseStatistic(time);
+        frs.incrementCount();
+        saveEntity(frs);
+        return makeAttributes(frs);
+    }
+
+    public FeedbackResponseStatistic getFeedbackResponseStatistic(Instant time) {
+        return load().id(FeedbackResponseStatistic.generateId(time)).now();
+    }
+
+    @Override
+    LoadType<FeedbackResponseStatistic> load() {
+        return ofy().load().type(FeedbackResponseStatistic.class);
+    }
+
+    @Override
+    boolean hasExistingEntities(FeedbackResponseStatisticAttributes entityToCreate) {
+        return !load()
+                .filterKey(Key.create(FeedbackResponseStatisticAttributes.class,
+                        FeedbackResponseStatistic.generateId(entityToCreate.getTime())))
+                .list()
+                .isEmpty();
+    }
+
+    @Override
+    FeedbackResponseStatisticAttributes makeAttributes(FeedbackResponseStatistic entity) {
+        Assumption.assertNotNull(entity);
+        return FeedbackResponseStatisticAttributes.valueOf(entity);
+    }
+}

--- a/src/main/java/teammates/storage/api/OfyHelper.java
+++ b/src/main/java/teammates/storage/api/OfyHelper.java
@@ -12,6 +12,7 @@ import teammates.storage.entity.CourseStudent;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackResponseComment;
+import teammates.storage.entity.FeedbackResponseStatistic;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.StudentProfile;
@@ -31,6 +32,7 @@ public class OfyHelper implements ServletContextListener {
         ObjectifyService.register(FeedbackQuestion.class);
         ObjectifyService.register(FeedbackResponse.class);
         ObjectifyService.register(FeedbackResponseComment.class);
+        ObjectifyService.register(FeedbackResponseStatistic.class);
         ObjectifyService.register(FeedbackSession.class);
         ObjectifyService.register(Instructor.class);
         ObjectifyService.register(StudentProfile.class);

--- a/src/main/java/teammates/storage/entity/FeedbackResponseStatistic.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseStatistic.java
@@ -1,0 +1,74 @@
+package teammates.storage.entity;
+
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.OnSave;
+import com.googlecode.objectify.annotation.Translate;
+import com.googlecode.objectify.annotation.Unindex;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Represents a feedback response statistic.
+ */
+@Entity
+@Index
+public class FeedbackResponseStatistic extends BaseEntity {
+
+    /**
+     * The unique id of the entity.
+     *
+     * @see #generateId(Instant)
+     */
+    @Id
+    private long id;
+
+    @Translate(InstantTranslatorFactory.class)
+    private Instant time;
+
+    @Unindex
+    private int count;
+
+    @SuppressWarnings("unused")
+    private FeedbackResponseStatistic() {
+        // required by Objectify
+    }
+
+    public FeedbackResponseStatistic(Instant time, int count) {
+        setTime(time);
+        setCount(count);
+        this.id = generateId(time);
+    }
+
+    /**
+     * Generates an unique ID for the feedback response statistic.
+     * Rounds down to the nearest minute.
+     */
+    public static long generateId(Instant time) {
+        return time.truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
+    }
+
+    public void setTime(Instant time) {
+        this.time = time.truncatedTo(ChronoUnit.MINUTES);
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public void incrementCount() {
+        if (this.count + 1 > this.count) {
+            this.count++;
+        }
+    }
+
+    public Instant getTime() {
+        return this.time;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/teammates/ui/output/FeedbackResponseStatData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseStatData.java
@@ -9,10 +9,9 @@ public class FeedbackResponseStatData extends ApiOutput {
 
     private final int number;
 
-    public FeedbackResponseStatData() {
-        this.responseTimeStamp = 0;
-        this.number = 0;
-        // TODO: Create new attributes or reuse existing attribute
+    public FeedbackResponseStatData(long responseTimeStamp, int number) {
+        this.responseTimeStamp = responseTimeStamp;
+        this.number = number;
     }
 
     public long getResponseTimeStamp() {

--- a/src/main/java/teammates/ui/output/FeedbackResponseStatsData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseStatsData.java
@@ -10,9 +10,8 @@ public class FeedbackResponseStatsData extends ApiOutput {
 
     private final List<FeedbackResponseStatData> feedbackResponseStats;
 
-    public FeedbackResponseStatsData() {
-        // TODO: Expected format for frontend consumption
-        feedbackResponseStats = new ArrayList<>();
+    public FeedbackResponseStatsData(List<FeedbackResponseStatData> feedbackResponseStats) {
+        this.feedbackResponseStats = feedbackResponseStats;
     }
 
     public List<FeedbackResponseStatData> getFeedbackResponseStats() {

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponseStatistics.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponseStatistics.java
@@ -1,10 +1,54 @@
 package teammates.ui.webapi;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+
+import teammates.common.datatransfer.attributes.FeedbackResponseStatisticAttributes;
+import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.InvalidParametersException;
+import teammates.common.util.Const;
+import teammates.ui.output.FeedbackResponseStatData;
+import teammates.ui.output.FeedbackResponseStatsData;
+import teammates.storage.entity.FeedbackResponseStatistic;
+
 public class GetFeedbackResponseStatistics extends AdminOnlyAction {
 
     @Override
     JsonResult execute() {
-        // TODO: Implement retrieving the feedback response statistics. Should be a simple fetch
-        return null;
+        String startTimestampStr = getRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_STATISTICS_START);
+        String endTimestampStr = getRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_STATISTICS_END);
+
+        if (startTimestampStr ==  null || endTimestampStr == null) {
+            return new JsonResult("Error: no start and end time", HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // TODO: Error handling, if the types are wrong (not long), also ensure that start <= end
+        long startTimestamp = Long.parseLong(startTimestampStr);
+        long endTimestamp = Long.parseLong(endTimestampStr);
+        Instant start = Instant.ofEpochMilli(startTimestamp);
+        Instant end = Instant.ofEpochMilli(endTimestamp);
+
+        // TODO: this is for testing create only, delete this later
+        try {
+            logic.createFeedbackResponseStatistic(Instant.now());
+        } catch (Exception e) {
+            System.out.println("@@@ PROBLEM CREATING FEEDBACK RESPONSES STATISTIC @@@");
+            System.out.println(e);
+        }
+
+        List<FeedbackResponseStatisticAttributes> statsAttributes = logic.getFeedbackResponseStatistics(start, end);
+
+        List<FeedbackResponseStatData> statsData = new ArrayList<>();
+        statsAttributes.forEach(statAttribute -> {
+            long responseTimeStamp = statAttribute.getTime().toEpochMilli();
+            int count = statAttribute.getCount();
+            FeedbackResponseStatData statData = new FeedbackResponseStatData(responseTimeStamp, count);
+            statsData.add(statData);
+        });
+        FeedbackResponseStatsData result = new FeedbackResponseStatsData(statsData);
+        return new JsonResult(result);
     }
 }


### PR DESCRIPTION
The API now works: a `GET` request to `localhost:8080/webapi/responses/statistics?frsstart=1611000000000&frsend=1612000000000` might return something like this (is this an OK format?):
```
{
    "feedbackResponseStats": [
        {
            "responseTimeStamp": 1611644220000,
            "number": 1
        },
        {
            "responseTimeStamp": 1611646140000,
            "number": 5
        },
        {
            "responseTimeStamp": 1611646200000,
            "number": 1
        },
    ],
    "requestId": "600fc663000098581b645389"
}
```

Also the logic/db/data/attributes for feedback response statistics have also been created, but the logic/db side is still incomplete (no logic for deleting statistics just yet).

(Some TODO and provisional things are still in there, like currently it creates a new statistic upon every API request. Also the code now probably won't pass lint)