### PR TITLE
Update Feedback Response Statistics in Submit Response API call

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1362,6 +1362,11 @@ public class Logic {
         return feedbackResponseStatisticsLogic.createFeedbackResponseStatistic(time);
     }
 
+    public void deleteFeedbackResponseStatistic(Instant time) {
+        Assumption.assertNotNull(time);
+        feedbackResponseStatisticsLogic.deleteFeedbackResponseStatistic(time);
+    }
+
     public String getSectionForTeam(String courseId, String teamName) {
         Assumption.assertNotNull(courseId);
         Assumption.assertNotNull(teamName);

--- a/src/main/java/teammates/logic/core/FeedbackResponseStatisticsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseStatisticsLogic.java
@@ -65,6 +65,18 @@ public final class FeedbackResponseStatisticsLogic {
         }
     }
 
+    /**
+     * Decrements the feedback response statistic using the timestamp.
+     * If the feedback response statistic has only one count, delete the entity from the database.
+     */
+    public void deleteFeedbackResponseStatistic(Instant time) {
+        if (frsDb.isFeedbackResponseStatisticCountOne(time)) { // count is going to be zero, delete
+            frsDb.deleteFeedbackResponseStatistic(time);
+        } else { // decrement
+            frsDb.decrementFeedbackResponseStatistic(time);
+        }
+    }
+
     public static FeedbackResponseStatisticsLogic inst() {
         return instance;
     }

--- a/src/main/java/teammates/storage/api/FeedbackResponseStatisticsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseStatisticsDb.java
@@ -20,6 +20,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
+import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackResponseStatistic;
 
 /**
@@ -48,6 +49,10 @@ public class FeedbackResponseStatisticsDb extends EntitiesDb<FeedbackResponseSta
         return getFeedbackResponseStatistic(time) != null;
     }
 
+    public boolean isFeedbackResponseStatisticCountOne(Instant time) {
+        return getFeedbackResponseStatistic(time).getCount() == 1;
+    }
+
     public FeedbackResponseStatisticAttributes incrementFeedbackResponseStatistic(Instant time) {
         FeedbackResponseStatistic frs = getFeedbackResponseStatistic(time);
         frs.incrementCount();
@@ -55,8 +60,24 @@ public class FeedbackResponseStatisticsDb extends EntitiesDb<FeedbackResponseSta
         return makeAttributes(frs);
     }
 
+    public void decrementFeedbackResponseStatistic(Instant time) {
+        FeedbackResponseStatistic frs = getFeedbackResponseStatistic(time);
+        frs.decrementCount();
+        saveEntity(frs);
+    }
+
     public FeedbackResponseStatistic getFeedbackResponseStatistic(Instant time) {
         return load().id(FeedbackResponseStatistic.generateId(time)).now();
+    }
+    /**
+     *
+     * Deletes a feedback response statistic.
+     */
+    public void deleteFeedbackResponseStatistic(Instant time) {
+        Assumption.assertNotNull(time);
+        long statisticId = FeedbackResponseStatistic.generateId(time);
+
+        deleteEntity(Key.create(FeedbackResponseStatistic.class, statisticId));
     }
 
     @Override

--- a/src/main/java/teammates/storage/entity/FeedbackResponseStatistic.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseStatistic.java
@@ -6,6 +6,7 @@ import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.OnSave;
 import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
+import teammates.common.util.Assumption;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -62,6 +63,11 @@ public class FeedbackResponseStatistic extends BaseEntity {
         if (this.count + 1 > this.count) {
             this.count++;
         }
+    }
+
+    public void decrementCount() {
+        Assumption.assertTrue(count > 0);
+        this.count--;
     }
 
     public Instant getTime() {

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponseStatistics.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponseStatistics.java
@@ -31,14 +31,6 @@ public class GetFeedbackResponseStatistics extends AdminOnlyAction {
         Instant start = Instant.ofEpochMilli(startTimestamp);
         Instant end = Instant.ofEpochMilli(endTimestamp);
 
-        // TODO: this is for testing create only, delete this later
-        try {
-            logic.createFeedbackResponseStatistic(Instant.now());
-        } catch (Exception e) {
-            System.out.println("@@@ PROBLEM CREATING FEEDBACK RESPONSES STATISTIC @@@");
-            System.out.println(e);
-        }
-
         List<FeedbackResponseStatisticAttributes> statsAttributes = logic.getFeedbackResponseStatistics(start, end);
 
         List<FeedbackResponseStatData> statsData = new ArrayList<>();

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -202,6 +204,9 @@ class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
 
         for (FeedbackResponseAttributes feedbackResponse : feedbackResponsesToDelete) {
             logic.deleteFeedbackResponseCascade(feedbackResponse.getId());
+
+            Instant time = feedbackResponse.getCreatedAt().truncatedTo(ChronoUnit.MINUTES);
+            logic.deleteFeedbackResponseStatistic(time);
         }
 
         List<FeedbackResponseAttributes> output = new ArrayList<>();
@@ -209,6 +214,7 @@ class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         for (FeedbackResponseAttributes feedbackResponse : feedbackResponsesToAdd) {
             try {
                 output.add(logic.createFeedbackResponse(feedbackResponse));
+                logic.createFeedbackResponseStatistic(Instant.now());
             } catch (InvalidParametersException | EntityAlreadyExistsException e) {
                 throw new InvalidHttpRequestBodyException(e.getMessage(), e);
             }
@@ -217,6 +223,7 @@ class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         for (FeedbackResponseAttributes.UpdateOptions feedbackResponse : feedbackResponsesToUpdate) {
             try {
                 output.add(logic.updateFeedbackResponseCascade(feedbackResponse));
+                logic.createFeedbackResponseStatistic(Instant.now());
             } catch (InvalidParametersException | EntityAlreadyExistsException | EntityDoesNotExistException e) {
                 throw new InvalidHttpRequestBodyException(e.getMessage(), e);
             }


### PR DESCRIPTION
Behaviour:

- Each question response is counted as a response statistic
- A new question response is added to the current timestamp
- A question response that is deleted, deletes the statistic in its created time (and not the current time)
- An updated question response just adds to the current timestamp and does not delete the old statistic (should we create a second parameter in the statistics object? Like one for create and one for update instead of a single number?)

Assumptions for Frontend
- When a stats object is deleted, the count is decremented. Hence, if the count is decremented to 0, the object is deleted from the DB. So, if a minute timestamp does not have a stats object, it is safe to assume that the number is 0. (either because no new add/all deleted)